### PR TITLE
fix: Order `moduleFileExtensions` left-to-right

### DIFF
--- a/examples/with-typescript-graphql/jest.config.js
+++ b/examples/with-typescript-graphql/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   roots: ['<rootDir>'],
-  moduleFileExtensions: ['js', 'ts', 'tsx', 'json'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'jsx'],
   testPathIgnorePatterns: ['<rootDir>[/\\\\](node_modules|.next)[/\\\\]'],
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(ts|tsx)$'],
   transform: {


### PR DESCRIPTION
Order moduleFileExtensions from most used least used extensions.

Sources: https://jestjs.io/docs/en/configuration#modulefileextensions-arraystring
and facebook/jest#7616